### PR TITLE
Added exception handling in grad_total_variation

### DIFF
--- a/gridencoder/grid.py
+++ b/gridencoder/grid.py
@@ -178,7 +178,7 @@ class GridEncoder(nn.Module):
         S = np.log2(self.per_level_scale) # resolution multiplier at each level, apply log2 for later CUDA exp2f
         H = self.base_resolution # base resolution
 
-        if inputs is None:
+        if inputs is None inputs.size(0) == 0:
             # randomized in [0, 1]
             inputs = torch.rand(B, self.input_dim, device=self.embeddings.device)
         else:


### PR DESCRIPTION
Exception handling added when size of input tensor is (0, 3) it happened when I set --bound >= 4. 

In that case, "RuntimeError: CUDA error: invalid configuration argument" is raised.