### PR TITLE
Add compatibility for torch 2.1 which based on c++17

### DIFF
--- a/freqencoder/backend.py
+++ b/freqencoder/backend.py
@@ -1,5 +1,9 @@
 import os
 from torch.utils.cpp_extension import load
+from packaging import version
+import torch
+
+torch_version = torch.__version__
 
 _src_path = os.path.dirname(os.path.abspath(__file__))
 
@@ -11,6 +15,16 @@ nvcc_flags = [
 
 if os.name == "posix":
     c_flags = ['-O3', '-std=c++14']
+    if version.parse(torch_version) >= version.parse("2.1"):
+        nvcc_flags = [
+            '-O3', '-std=c++17',
+            '-U__CUDA_NO_HALF_OPERATORS__', '-U__CUDA_NO_HALF_CONVERSIONS__', '-U__CUDA_NO_HALF2_OPERATORS__',
+            '-use_fast_math'
+        ]
+        c_flags = ['-O3', '-std=c++17']
+
+
+
 elif os.name == "nt":
     c_flags = ['/O2', '/std:c++17']
 

--- a/freqencoder/setup.py
+++ b/freqencoder/setup.py
@@ -1,6 +1,10 @@
 import os
 from setuptools import setup
 from torch.utils.cpp_extension import BuildExtension, CUDAExtension
+from packaging import version
+import torch
+
+torch_version = torch.__version__
 
 _src_path = os.path.dirname(os.path.abspath(__file__))
 
@@ -12,6 +16,14 @@ nvcc_flags = [
 
 if os.name == "posix":
     c_flags = ['-O3', '-std=c++14']
+    if version.parse(torch_version) >= version.parse("2.1"):
+        nvcc_flags = [
+            '-O3', '-std=c++17',
+            '-U__CUDA_NO_HALF_OPERATORS__', '-U__CUDA_NO_HALF_CONVERSIONS__', '-U__CUDA_NO_HALF2_OPERATORS__',
+            '-use_fast_math'
+        ]
+        c_flags = ['-O3', '-std=c++17']
+
 elif os.name == "nt":
     c_flags = ['/O2', '/std:c++17']
 

--- a/gridencoder/backend.py
+++ b/gridencoder/backend.py
@@ -1,5 +1,9 @@
 import os
 from torch.utils.cpp_extension import load
+from packaging import version
+import torch
+
+torch_version = torch.__version__
 
 _src_path = os.path.dirname(os.path.abspath(__file__))
 
@@ -10,6 +14,13 @@ nvcc_flags = [
 
 if os.name == "posix":
     c_flags = ['-O3', '-std=c++14']
+    if version.parse(torch_version) >= version.parse("2.1"):
+        nvcc_flags = [
+            '-O3', '-std=c++17',
+            '-U__CUDA_NO_HALF_OPERATORS__', '-U__CUDA_NO_HALF_CONVERSIONS__', '-U__CUDA_NO_HALF2_OPERATORS__',
+            '-use_fast_math'
+        ]
+        c_flags = ['-O3', '-std=c++17']
 elif os.name == "nt":
     c_flags = ['/O2', '/std:c++17']
 

--- a/gridencoder/setup.py
+++ b/gridencoder/setup.py
@@ -1,6 +1,10 @@
 import os
 from setuptools import setup
 from torch.utils.cpp_extension import BuildExtension, CUDAExtension
+from packaging import version
+import torch
+
+torch_version = torch.__version__
 
 _src_path = os.path.dirname(os.path.abspath(__file__))
 
@@ -11,6 +15,13 @@ nvcc_flags = [
 
 if os.name == "posix":
     c_flags = ['-O3', '-std=c++14']
+    if version.parse(torch_version) >= version.parse("2.1"):
+        nvcc_flags = [
+            '-O3', '-std=c++17',
+            '-U__CUDA_NO_HALF_OPERATORS__', '-U__CUDA_NO_HALF_CONVERSIONS__', '-U__CUDA_NO_HALF2_OPERATORS__',
+            '-use_fast_math'
+        ]
+        c_flags = ['-O3', '-std=c++17']
 elif os.name == "nt":
     c_flags = ['/O2', '/std:c++17']
 

--- a/raymarching/backend.py
+++ b/raymarching/backend.py
@@ -1,5 +1,9 @@
 import os
 from torch.utils.cpp_extension import load
+from packaging import version
+import torch
+
+torch_version = torch.__version__
 
 _src_path = os.path.dirname(os.path.abspath(__file__))
 
@@ -10,6 +14,13 @@ nvcc_flags = [
 
 if os.name == "posix":
     c_flags = ['-O3', '-std=c++14']
+    if version.parse(torch_version) >= version.parse("2.1"):
+        nvcc_flags = [
+            '-O3', '-std=c++17',
+            '-U__CUDA_NO_HALF_OPERATORS__', '-U__CUDA_NO_HALF_CONVERSIONS__', '-U__CUDA_NO_HALF2_OPERATORS__',
+            '-use_fast_math'
+        ]
+        c_flags = ['-O3', '-std=c++17']
 elif os.name == "nt":
     c_flags = ['/O2', '/std:c++17']
 

--- a/raymarching/setup.py
+++ b/raymarching/setup.py
@@ -1,6 +1,10 @@
 import os
 from setuptools import setup
 from torch.utils.cpp_extension import BuildExtension, CUDAExtension
+from packaging import version
+import torch
+
+torch_version = torch.__version__
 
 _src_path = os.path.dirname(os.path.abspath(__file__))
 
@@ -11,6 +15,13 @@ nvcc_flags = [
 
 if os.name == "posix":
     c_flags = ['-O3', '-std=c++14']
+    if version.parse(torch_version) >= version.parse("2.1"):
+        nvcc_flags = [
+            '-O3', '-std=c++17',
+            '-U__CUDA_NO_HALF_OPERATORS__', '-U__CUDA_NO_HALF_CONVERSIONS__', '-U__CUDA_NO_HALF2_OPERATORS__',
+            '-use_fast_math'
+        ]
+        c_flags = ['-O3', '-std=c++17']
 elif os.name == "nt":
     c_flags = ['/O2', '/std:c++17']
 

--- a/shencoder/backend.py
+++ b/shencoder/backend.py
@@ -1,5 +1,9 @@
 import os
 from torch.utils.cpp_extension import load
+from packaging import version
+import torch
+
+torch_version = torch.__version__
 
 _src_path = os.path.dirname(os.path.abspath(__file__))
 
@@ -10,6 +14,13 @@ nvcc_flags = [
 
 if os.name == "posix":
     c_flags = ['-O3', '-std=c++14']
+    if version.parse(torch_version) >= version.parse("2.1"):
+        nvcc_flags = [
+            '-O3', '-std=c++17',
+            '-U__CUDA_NO_HALF_OPERATORS__', '-U__CUDA_NO_HALF_CONVERSIONS__', '-U__CUDA_NO_HALF2_OPERATORS__',
+            '-use_fast_math'
+        ]
+        c_flags = ['-O3', '-std=c++17']
 elif os.name == "nt":
     c_flags = ['/O2', '/std:c++17']
 

--- a/shencoder/setup.py
+++ b/shencoder/setup.py
@@ -1,6 +1,10 @@
 import os
 from setuptools import setup
 from torch.utils.cpp_extension import BuildExtension, CUDAExtension
+from packaging import version
+import torch
+
+torch_version = torch.__version__
 
 _src_path = os.path.dirname(os.path.abspath(__file__))
 
@@ -11,6 +15,13 @@ nvcc_flags = [
 
 if os.name == "posix":
     c_flags = ['-O3', '-std=c++14']
+    if version.parse(torch_version) >= version.parse("2.1"):
+        nvcc_flags = [
+            '-O3', '-std=c++17',
+            '-U__CUDA_NO_HALF_OPERATORS__', '-U__CUDA_NO_HALF_CONVERSIONS__', '-U__CUDA_NO_HALF2_OPERATORS__',
+            '-use_fast_math'
+        ]
+        c_flags = ['-O3', '-std=c++17']
 elif os.name == "nt":
     c_flags = ['/O2', '/std:c++17']
 


### PR DESCRIPTION
Add c++17 compatibility with extensions,

after torch [2.1](https://github.com/pytorch/pytorch/pull/100557),
building pytorch from source requires c++17,

Add version check for torch and add parts to set c++ flags